### PR TITLE
 #Issue10_Split words using \\W+ regex

### DIFF
--- a/src/main/scala/com/danielasfregola/zucchini/Dictionary.scala
+++ b/src/main/scala/com/danielasfregola/zucchini/Dictionary.scala
@@ -13,7 +13,7 @@ object Dictionary extends App {
   }
 
   private def allWords(texts: Iterator[String]): Iterator[String] = {
-    texts.flatMap(line => line.split("[^a-zA-Z0-9']+")).map(_.trim)
+    texts.flatMap(line => line.split("\\W+"))
   }
 
   println(extractUniqueWordsFromTextFile("BaconipSum.txt").mkString(","))

--- a/src/test/scala/com/danielasfregola/zucchini/DictionaryTest.scala
+++ b/src/test/scala/com/danielasfregola/zucchini/DictionaryTest.scala
@@ -9,7 +9,7 @@ class DictionaryTest extends WordSpecLike {
 
     "extractUniqueWordsFromTextFile" should {
 
-      "and return 6 unique words" in {
+      "return 6 unique words" in {
         assertResult(Set("rabbit", "lion", "pig", "horse", "Goat", "uniCorn23")) {
           extractUniqueWordsFromTextFile("myWords.txt")
         }
@@ -17,11 +17,10 @@ class DictionaryTest extends WordSpecLike {
     }
 
     "return letters or digits only" in {
-      assertResult(Set("Bacon", "ipsum", "dolor", "amet", "land", "jaeger", "chicken", "jowl", "Venison",
+      assertResult(Set("Bacon", "ipsum", "dolor_amet", "land", "jaeger", "chicken", "jowl", "Venison",
         "doner", "shoulder", "tri", "tip", "pig2", "boudin")) {
         extractUniqueWordsFromTextFile("BaconipSumTest.txt")
       }
     }
-
   }
 }


### PR DESCRIPTION
Use regex \W: to avoid  from looping through the list of words again to trim.